### PR TITLE
Set rendering timestamp in renderTime

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -127,8 +127,9 @@ Element Timing involves the following new interfaces:
 
 <pre class="idl">
 interface PerformanceElementTiming : PerformanceEntry {
-    readonly attribute DOMRectReadOnly intersectionRect;
+    readonly attribute DOMHighResTimeStamp renderTime;
     readonly attribute DOMHighResTimeStamp responseEnd;
+    readonly attribute DOMRectReadOnly intersectionRect;
     readonly attribute DOMString identifier;
     readonly attribute unsigned long naturalWidth;
     readonly attribute unsigned long naturalHeight;
@@ -150,9 +151,11 @@ The {{PerformanceEntry/entryType}} attribute's getter must return the {{DOMStrin
 
 The {{PerformanceEntry/name}} attribute's getter must return the value it was initialized to.
 
-The {{PerformanceEntry/startTime}} attribute must return the value it was initialized to.
+The {{PerformanceEntry/startTime}} attribute's getter must return 0.
 
 The {{PerformanceEntry/duration}} attribute's getter must return 0.
+
+The {{PerformanceElementTiming/renderTime}} attribute must return the value it was initialized to.
 
 The {{PerformanceElementTiming/intersectionRect}} attribute must return the value it was initialized to.
 
@@ -263,7 +266,7 @@ Report image Element Timing {#sec-report-image-element}
     1. Set |entry|'s <a>request</a> to |imageRequest|.
     1. Set |entry|'s <a>element</a> to |image|.
     1. Set |entry|'s {{PerformanceEntry/name}} to the {{DOMString}} "image-paint".
-    1. Set |entry|'s {{PerformanceEntry/startTime}} to |renderTime|.
+    1. Set |entry|'s {{renderTime}} to |renderTime|.
     1. Set |entry|'s {{intersectionRect}} to |intersectionRect|.
     1. Set |entry|'s {{PerformanceElementTiming/naturalWidth}} and {{PerformanceElementTiming/naturalHeight}} by running the same steps for an <{img}>'s {{img/naturalWidth}} and {{img/naturalHeight}} attribute getters, but using |image| as the image.
     1. <a>Queue the PerformanceEntry</a> |entry|.
@@ -285,7 +288,7 @@ Report text Element Timing {#sec-report-text}
     1. Create a {{PerformanceElementTiming}} object |entry|.
     1. Set |entry|'s <a>element</a> to |element|.
     1. Set |entry|'s {{PerformanceEntry/name}} to the {{DOMString}} "text-paint".
-    1. Set |entry|'s {{PerformanceEntry/startTime}} to |renderTime|.
+    1. Set |entry|'s {{renderTime}} to |renderTime|.
     1. Set |entry|'s {{intersectionRect}} to |intersectionRect|.
     1. Set |entry|'s {{PerformanceElementTiming/naturalWidth}} and {{PerformanceElementTiming/naturalHeight}} to 0.
     1. <a>Queue the PerformanceEntry</a> |entry|.
@@ -341,7 +344,7 @@ The <a>current high resolution time</a> computed at the beginning of the onload 
 We choose to expose the {{responseEnd}} because it is very easy to obtain even without an onload handler.
 In addition, we believe any fix to remove the leak provided by image onload handlers or ResourceTiming could also fix the leak provided by this API.
 
-The {{PerformanceEntry/startTime}} (display timestamp) can also be polyfilled via the PaintTiming API.
+The {{renderTime}} (display timestamp) can also be polyfilled via the PaintTiming API.
 To do this, add an iframe that contains trivial content on the onload handler of the target image or text content.
 Then, query the first paint of that iframe to obtain the rendering timestamp of the content.
 This is quite inefficient and the polyfill itself might affect the timing obtained.

--- a/index.bs
+++ b/index.bs
@@ -157,9 +157,9 @@ The {{PerformanceEntry/duration}} attribute's getter must return 0.
 
 The {{PerformanceElementTiming/renderTime}} attribute must return the value it was initialized to.
 
-The {{PerformanceElementTiming/intersectionRect}} attribute must return the value it was initialized to.
-
 The {{PerformanceElementTiming/responseEnd}} attribute's getter must return the result of running <a>get response end time</a> with the <a>context object</a>'s <a>request</a> as input.
+
+The {{PerformanceElementTiming/intersectionRect}} attribute must return the value it was initialized to.
 
 The {{PerformanceElementTiming/identifier}} attribute's getter must return <a>element</a>'s {{elementtiming}} attribute value.
 


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/element-timing/pull/15.html" title="Last updated on Jul 16, 2019, 3:21 PM UTC (271c09a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/element-timing/15/e136166...271c09a.html" title="Last updated on Jul 16, 2019, 3:21 PM UTC (271c09a)">Diff</a>