### PR TITLE
Add loadTime to potentially-add-LCP

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -60,7 +60,7 @@ urlPrefix: https://fetch.spec.whatwg.org; spec: FETCH;
 urlPrefix: https://drafts.csswg.org/css2/zindex.html; spec: CSS;
     type: dfn; url:#painting-order; text: painting order;
 urlPrefix: https://wicg.github.io/largest-contentful-paint/; spec: LARGEST-CONTENTFUL-PAINT;
-    type: dfn; url:#potentially-add-a-performancelargestcontentfulpaintcandidate-entry; text: potentially add a Largest-Contentful-Paint-Candidate entry;
+    type: dfn; url:#potentially-add-a-largestcontentfulpaint-entry; text: potentially add a Largest-Contentful-Paint-Candidate entry;
 </pre>
 
 Introduction {#sec-intro}
@@ -273,7 +273,7 @@ Report image Element Timing {#sec-report-image-element}
 
     1. Let |intersectionRect| be the value returned by the <a>intersection rect algorithm</a> using |element| as the target and viewport as the root.
     1. Let |exposedElement| be the result of running [=get an element=] with |element| and |document| as input.
-    1. If |exposedElement| is not null, call the <a>potentially add a Largest-Contentful-Paint-Candidate entry</a> algorithm with |intersectionRect|, |imageRequest|, |renderTime|, |element|, and |document|.
+    1. If |exposedElement| is not null, call the <a>potentially add a Largest-Contentful-Paint-Candidate entry</a> algorithm with |intersectionRect|, |imageRequest|, |renderTime|, |loadTime|, |element|, and |document|.
     1. If the |element|'s {{Element/elementtiming}} attribute getter returns a {{DOMString}} of zero length, then abort these steps.
     1. Create a {{PerformanceElementTiming}} object |entry|.
     1. Set |entry|'s <a>request</a> to |imageRequest|.
@@ -297,12 +297,13 @@ Report text Element Timing {#sec-report-text}
         1. Augment |intersectionRect| to be smallest rectangle containing the border box of |text| and |intersectionRect|.
     1. Intersect |intersectionRect| with the visual viewport.
     1. Let |exposedElement| be the result of running [=get an element=] with |element| and |document| as input.
-    1. If |exposedElement| is not null, call the <a>potentially add a Largest-Contentful-Paint-Candidate entry</a> algorithm with |intersectionRect|, null, |renderTime|, |exposedElement|, and |document|.
+    1. If |exposedElement| is not null, call the <a>potentially add a Largest-Contentful-Paint-Candidate entry</a> algorithm with |intersectionRect|, null, |renderTime|, 0, |exposedElement|, and |document|.
     1. If |element|'s {{Element/elementtiming}} attribute getter returns a {{DOMString}} of zero length and if |intersectionRect|'s size is smaller than 15% of the viewport size, then abort these steps.
     1. Create a {{PerformanceElementTiming}} object |entry|.
     1. Set |entry|'s <a>element</a> to |element|.
     1. Set |entry|'s {{PerformanceEntry/name}} to the {{DOMString}} "text-paint".
     1. Set |entry|'s {{renderTime}} to |renderTime|.
+    1. Set |entry|'s {{loadTime}} to 0.
     1. Set |entry|'s {{intersectionRect}} to |intersectionRect|.
     1. Set |entry|'s {{PerformanceElementTiming/naturalWidth}} and {{PerformanceElementTiming/naturalHeight}} to 0.
     1. <a>Queue the PerformanceEntry</a> |entry|.


### PR DESCRIPTION
This PR does several minor fixes in the calling of the LCP algorithm.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/element-timing/pull/17.html" title="Last updated on Jul 25, 2019, 4:12 PM UTC (8c1e412)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/element-timing/17/c22bec1...8c1e412.html" title="Last updated on Jul 25, 2019, 4:12 PM UTC (8c1e412)">Diff</a>