### PR TITLE
Add poster of video to Elements Exposed

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -83,6 +83,7 @@ Elements exposed {#sec-elements-exposed}
 The Element Timing API supports timing information about the following elements:
 * <{img}> elements.
 * <{image}> elements inside an <{svg}>.
+* The poster images of <{video}> elements.
 * Elements with a <a>background-image</a>.
 * Groups of text nodes, which are aggregated as described in [[#sec-modifications-CSS]].
 


### PR DESCRIPTION
Fixes https://github.com/WICG/element-timing/issues/32


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/element-timing/pull/34.html" title="Last updated on Aug 14, 2019, 3:03 PM UTC (e330509)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/element-timing/34/11caf94...e330509.html" title="Last updated on Aug 14, 2019, 3:03 PM UTC (e330509)">Diff</a>