### PR TITLE
Allow just setting the elementtiming attribute

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -273,7 +273,7 @@ Report image Element Timing {#sec-report-image-element}
     1. Let |intersectionRect| be the value returned by the <a>intersection rect algorithm</a> using |element| as the target and viewport as the root.
     1. Let |exposedElement| be the result of running [=get an element=] with |element| and |document| as input.
     1. If |exposedElement| is not null, call the <a>potentially add a LargestContentfulPaint entry</a> algorithm with |intersectionRect|, |imageRequest|, |renderTime|, |loadTime|, |element|, and |document|.
-    1. If |element|'s "<code>elementtiming</code>" content attribute is absent or if its value is the empty string, then abort these steps.
+    1. If |element|'s "<code>elementtiming</code>" content attribute is absent, then abort these steps.
     1. Create and initialize a {{PerformanceElementTiming}} object |entry|.
         1. Initialize |entry|'s <a>request</a> to |imageRequest|.
         1. Initialize |entry|'s <a>element</a> to |element|.
@@ -299,7 +299,7 @@ Report text Element Timing {#sec-report-text}
     1. Intersect |intersectionRect| with the visual viewport.
     1. Let |exposedElement| be the result of running [=get an element=] with |element| and |document| as input.
     1. If |exposedElement| is not null, call the <a>potentially add a LargestContentfulPaint entry</a> algorithm with |intersectionRect|, null, |renderTime|, 0, |exposedElement|, and |document|.
-    1. If |element|'s "<code>elementtiming</code>" content attribute is absent or if its value is the empty string, then abort these steps.
+    1. If |element|'s "<code>elementtiming</code>" content attribute is absent, then abort these steps.
     1. Create and initialize a {{PerformanceElementTiming}} object |entry|.
         1. Initialize |entry|'s <a>element</a> to |element|.
         1. Initialize |entry|'s {{PerformanceEntry/name}} to the {{DOMString}} "text-paint".


### PR DESCRIPTION
For https://github.com/WICG/element-timing/issues/37. When the attribute is set it should trigger observation, even if it is set to the empty string. This is useful because doing something such as <img ... elementtiming> sets the attribute value to the empty string.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/element-timing/pull/38.html" title="Last updated on Oct 18, 2019, 8:52 PM UTC (3c51e74)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/element-timing/38/1611e47...3c51e74.html" title="Last updated on Oct 18, 2019, 8:52 PM UTC (3c51e74)">Diff</a>