### PR TITLE
Pass global object to current high res time

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -259,7 +259,7 @@ To <dfn>process an image that finished loading</dfn> given |element| and |imageR
     1. Let |imageRequest| be |element|'s <a>associated image request</a>.
     1. Let |root| be |element|'s <a for="tree">root</a>.
     1. If |root| is not a {{Document}}, return.
-    1. Let |now| be the <a>current high resolution time</a>.
+    1. Let |now| be the <a>current high resolution time</a> given |element|'s <a>relevant global object</a>.
     1. If |imageRequest| is not a data URL [[RFC2397]] and if the <a>timing allow check</a> fails for |imageRequest|'s resource, run the <a>report image element timing</a> algorithm, passing in the triple (|element|, |imageRequest|, |now|), 0, and |root| as inputs.
     1. Otherwise, add the triple (|element|, |imageRequest|, |now|) to |root|'s <a>images pending rendering</a>.
 </div>


### PR DESCRIPTION
Fixes https://github.com/WICG/element-timing/issues/49


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/element-timing/pull/50.html" title="Last updated on Oct 6, 2020, 4:52 PM UTC (febb912)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/element-timing/50/200fa06...febb912.html" title="Last updated on Oct 6, 2020, 4:52 PM UTC (febb912)">Diff</a>