### PR TITLE
Remove context object

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -152,7 +152,7 @@ The {{PerformanceEntry/entryType}} attribute's getter must return the {{DOMStrin
 
 The {{PerformanceEntry/name}} attribute's getter must return the value it was initialized to.
 
-The {{PerformanceEntry/startTime}} attribute's getter must return the value of the <a>context object</a>'s {{renderTime}} if it is not 0, and the value of the <a>context object</a>'s {{loadTime}} otherwise.
+The {{PerformanceEntry/startTime}} attribute's getter must return the value of <a>this</a>'s {{renderTime}} if it is not 0, and the value of <a>this</a>'s {{loadTime}} otherwise.
 
 The {{PerformanceEntry/duration}} attribute's getter must return 0.
 
@@ -170,7 +170,7 @@ The {{PerformanceElementTiming/naturalHeight}} attribute must return the value i
 
 The {{PerformanceElementTiming/id}} attribute's getter must return the value it was initialized to.
 
-The {{PerformanceElementTiming/element}} attribute's getter must run the [=get an element=] algorithm with <a>context object</a>'s <a>element</a> and null as inputs.
+The {{PerformanceElementTiming/element}} attribute's getter must run the [=get an element=] algorithm <a>this</a>'s <a>element</a> and null as inputs.
 
 Note: This means that an element that is no longer <a>descendant</a> of the {{Document}} will no longer be returned by {{PerformanceElementTiming/element}}'s attribute getter.
 
@@ -336,7 +336,7 @@ Get an element algorithm {#sec-get-an-element}
 <div algorithm="PerformanceElementTiming element">
 When asked to run the <dfn>get an element</dfn> algorithm with {{Element}} |element| and {{Document}} |document| as inputs, run these steps:
     1. If |element| is not <a>connected</a>, return <code>null</code>.
-    1. Let |settings| be the <a>context object</a>'s <a>relevant settings object</a>.
+    1. Let |settings| be <a>this</a>'s <a>relevant settings object</a>.
     1. if |document| is null, let |document| be |settings|'s <a>responsible document</a>.
     1. If |element|'s <a for="tree">root</a> is not equal to |document| or if |document| is not [=fully active=], return <code>null</code>.
     1. Return |element|.


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 400 Bad Request :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on May 6, 2021, 9:26 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2FWICG%2Felement-timing%2F76ccc93669cddfb60bd4298a5ea0584f5836d3d3%2Findex.bs&md-warning=not%20ready)

```
Error running preprocessor, returned code: 2.
LINK ERROR: No 'dfn' refs found for 'context object'.
&lt;a data-link-type="dfn" data-lt="context object">context object&lt;/a>
FATAL ERROR: Couldn't load MDN Spec Links data for this spec.
Expecting value: line 1 column 1 (char 0)
 ✘  Did not generate, due to fatal errors
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20WICG/element-timing%2358.)._
</details>
