### PR TITLE
Use URL serializer

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -36,7 +36,6 @@ urlPrefix: https://w3c.github.io/IntersectionObserver; spec: INTERSECTION-OBSERV
 urlPrefix: https://w3c.github.io/paint-timing/; spec: PAINT-TIMING;
     type: dfn; url: #first-paint; text: first paint;
 urlPrefix: https://html.spec.whatwg.org/multipage; spec: HTML;
-    type: dfn; url: #image-request; text: image request;
     type: dfn; url: /images.html#img-all; text: completely available;
     type: dfn; url: images.html#list-of-available-images; text: list of available images;
     type: attribute; for: img;
@@ -142,7 +141,7 @@ interface PerformanceElementTiming : PerformanceEntry {
 A {{PerformanceElementTiming}} object reports timing information about one associated element.
 
 Each {{PerformanceElementTiming}} object has these associated concepts, all of which are initially set to <code>null</code>:
-* A <dfn>request</dfn> containing the image request (if the entry is for image content).
+* A <dfn>request</dfn> containing the <a>image request</a> (if the entry is for image content).
 * An <dfn>element</dfn> containing the associated {{Element}}.
 
 The associated concepts and some attributes for {{PerformanceElementTiming}} are specified in the processing model in [[#sec-report-image-element]] and [[#sec-report-text]].
@@ -176,7 +175,7 @@ Note: This means that an element that is no longer <a>descendant</a> of the {{Do
 The {{PerformanceElementTiming/url}} attribute's getter must perform the following steps:
 <div algorithm="PerformanceElementTiming url">
     1. If <a>this</a>'s <a>request</a> is null, return the empty string.
-    1. Let |urlString| be <a>this</a>'s <a>request</a>'s <a>current URL</a>.
+    1. Let |urlString| be <a>this</a>'s <a>request</a>'s <a for="image request">current URL</a>.
     1. Let |url| be the result of <a lt="URL parser">parsing</a> |urlString|.
     1. If |url|'s <a spec=url>scheme</a> is "`data`", trim |urlString| to its first 100 characters.
     1. Return |urlString|.

--- a/index.bs
+++ b/index.bs
@@ -178,7 +178,7 @@ The {{PerformanceElementTiming/url}} attribute's getter must perform the followi
     1. If <a>this</a>'s <a>request</a> is null, return the empty string.
     1. Let |urlString| be <a>this</a>'s <a>request</a>'s <a>current URL</a>.
     1. Let |url| be the result of <a lt="URL parser">parsing</a> |urlString|.
-    1. If |url|'s <a spec=url>scheme</a> is "data", trim |urlString| to its first 100 characters.
+    1. If |url|'s <a spec=url>scheme</a> is "`data`", trim |urlString| to its first 100 characters.
     1. Return |urlString|.
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -176,7 +176,8 @@ Note: This means that an element that is no longer <a>descendant</a> of the {{Do
 
 The {{PerformanceElementTiming/url}} attribute's getter must perform the following steps:
 <div algorithm="PerformanceElementTiming url">
-    1. Let |url| be <a>request</a>'s <a>resolved URL</a>.
+    1. If <a>this</a>'s <a>request</a> is null, return the empty string.
+    1. Let |url| be <a>this</a>'s <a>request</a>'s <a>resolved URL</a>.
     1. Let |urlString| be the result of <a lt="URL serializer">serializing</a> |url|.
     1. If |url|'s <a spec=url>scheme</a> is "data:", trim |urlString| to its first 100 characters.
     1. Return |urlString|.

--- a/index.bs
+++ b/index.bs
@@ -38,7 +38,6 @@ urlPrefix: https://w3c.github.io/paint-timing/; spec: PAINT-TIMING;
 urlPrefix: https://html.spec.whatwg.org/multipage; spec: HTML;
     type: dfn; url: #image-request; text: image request;
     type: dfn; url: /images.html#img-all; text: completely available;
-    type: dfn; url: /urls-and-fetching.html#resolve-a-url; text: resolved url;
     type: dfn; url: images.html#list-of-available-images; text: list of available images;
     type: attribute; for: img;
         text:naturalWidth; url: #dom-img-naturalwidth;
@@ -177,9 +176,9 @@ Note: This means that an element that is no longer <a>descendant</a> of the {{Do
 The {{PerformanceElementTiming/url}} attribute's getter must perform the following steps:
 <div algorithm="PerformanceElementTiming url">
     1. If <a>this</a>'s <a>request</a> is null, return the empty string.
-    1. Let |url| be <a>this</a>'s <a>request</a>'s <a>resolved URL</a>.
-    1. Let |urlString| be the result of <a lt="URL serializer">serializing</a> |url|.
-    1. If |url|'s <a spec=url>scheme</a> is "data:", trim |urlString| to its first 100 characters.
+    1. Let |urlString| be <a>this</a>'s <a>request</a>'s <a>current URL</a>.
+    1. Let |url| be the result of <a lt="URL parser">parsing</a> |urlString|.
+    1. If |url|'s <a spec=url>scheme</a> is "data", trim |urlString| to its first 100 characters.
     1. Return |urlString|.
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -176,9 +176,10 @@ Note: This means that an element that is no longer <a>descendant</a> of the {{Do
 
 The {{PerformanceElementTiming/url}} attribute's getter must perform the following steps:
 <div algorithm="PerformanceElementTiming url">
-    1. Let <var>url</var> be <a>request</a>'s <a>resolved URL</a>
-    1. If <var>url</var>'s <a spec=url>scheme</a> is "data:", trim <var>url</var> to its first 100 characters.
-    1. Return <var>url</var>.
+    1. Let |url| be <a>request</a>'s <a>resolved URL</a>.
+    1. Let |urlString| be the result of <a lt="URL serializer">serializing</a> |url|.
+    1. If |url|'s <a spec=url>scheme</a> is "data:", trim |urlString| to its first 100 characters.
+    1. Return |urlString|.
 </div>
 
 Note: The URL is trimmed for data URLs to avoid excessive memory in the entry.


### PR DESCRIPTION
Fixes https://github.com/WICG/element-timing/issues/62 and https://github.com/WICG/element-timing/issues/63
@annevk


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/element-timing/pull/66.html" title="Last updated on Nov 8, 2021, 4:41 PM UTC (77bb514)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/element-timing/66/e6b9765...77bb514.html" title="Last updated on Nov 8, 2021, 4:41 PM UTC (77bb514)">Diff</a>