### PR TITLE
Replace "viewport" with "Initial Containing Block"

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -250,7 +250,7 @@ Report image Element Timing {#sec-report-image-element}
 <div algorithm="report image element timing">
     When asked to <dfn>report image element timing</dfn> given a triple (|element|, |imageRequest|, |loadTime|), a DOMHighResTimestamp |renderTime| and a {{Document}} |document|, perform the following steps:
 
-    1. Let |intersectionRect| be the value returned by the <a>intersection rect algorithm</a> using |element| as the target and viewport as the root.
+    1. Let |intersectionRect| be the value returned by the <a>intersection rect algorithm</a> using |element| as the target and |document|'s [=initial containing block=] as the root.
     1. Let |exposedElement| be the result of running [=get an element=] with |element| and |document| as input.
     1. If |exposedElement| is not null, call the <a>potentially add a LargestContentfulPaint entry</a> algorithm with |intersectionRect|, |imageRequest|, |renderTime|, |loadTime|, |element|, and |document|.
     1. If |element|'s "<code>elementtiming</code>" content attribute is absent, then abort these steps.


### PR DESCRIPTION
This replaces the unlinked "viewport" term with a link to the document's initial containing block, which will be the bounds of the browser window or iframe containing the document.

Closes: w3c/largest-contentful-paint#26


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/clelland/element-timing/pull/76.html" title="Last updated on Aug 31, 2023, 5:08 PM UTC (14ad293)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/element-timing/76/0b34145...clelland:14ad293.html" title="Last updated on Aug 31, 2023, 5:08 PM UTC (14ad293)">Diff</a>