### PR TITLE
Update a couple of broken references

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -29,6 +29,7 @@ urlPrefix: https://w3c.github.io/IntersectionObserver; spec: INTERSECTION-OBSERV
     type: dfn; url: #calculate-intersection-rect-algo; text: intersection rect algorithm;
 urlPrefix: https://html.spec.whatwg.org/multipage; spec: HTML;
     type: dfn; url: /images.html#img-all; text: completely available;
+    type: dfn; url: //webappapis.html#event-loop-processing-model; text: event loop processing model;
 urlPrefix: https://drafts.csswg.org/css-backgrounds-3; spec: CSS-BACKGROUNDS-3;
     type: dfn; url: #propdef-background-image; text: background-image;
 urlPrefix: https://drafts.csswg.org/css2/zindex.html; spec: CSS;
@@ -37,6 +38,9 @@ urlPrefix: https://wicg.github.io/largest-contentful-paint/; spec: LARGEST-CONTE
     type: dfn; url:#potentially-add-a-largestcontentfulpaint-entry; text: potentially add a LargestContentfulPaint entry;
 urlPrefix: https://fetch.spec.whatwg.org/; spec: FETCH;
     type: dfn; url:#concept-tao-check; text: timing allow check;
+</pre>
+<pre class=link-defaults>
+spec:dom; type:dfn; text:descendant
 </pre>
 
 Introduction {#sec-intro}


### PR DESCRIPTION
* DIsambiguates "descendant"
* References HTML algorithm correctly (not exported, but that's almost certainly WAI; this is still a monkeypatch)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/clelland/element-timing/pull/77.html" title="Last updated on Oct 27, 2023, 2:54 PM UTC (096833f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/element-timing/77/0b34145...clelland:096833f.html" title="Last updated on Oct 27, 2023, 2:54 PM UTC (096833f)">Diff</a>