### PR TITLE
Convert the type of PerformanceElementTiming url attribute to USVString

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -125,7 +125,7 @@ interface PerformanceElementTiming : PerformanceEntry {
     readonly attribute unsigned long naturalHeight;
     readonly attribute DOMString id;
     readonly attribute Element? element;
-    readonly attribute DOMString url;
+    readonly attribute USVString url;
     [Default] object toJSON();
 };
 


### PR DESCRIPTION
Fixes #83.

This is quite a small change. Just changing the type of `url` from `DOMString` to `USVString`. Even though it's not a big issue, it would be good to be consistent here.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/canova/element-timing/pull/87.html" title="Last updated on Jun 3, 2025, 2:20 PM UTC (30162f1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/element-timing/87/7e74312...canova:30162f1.html" title="Last updated on Jun 3, 2025, 2:20 PM UTC (30162f1)">Diff</a>